### PR TITLE
fix: change default timezone from Asia/Shanghai to UTC

### DIFF
--- a/src/openclaw_ltk/clock.py
+++ b/src/openclaw_ltk/clock.py
@@ -6,12 +6,12 @@ from datetime import UTC, datetime
 from zoneinfo import ZoneInfo
 
 
-def now(tz_name: str = "Asia/Shanghai") -> datetime:
+def now(tz_name: str = "UTC") -> datetime:
     """Return current time in the given timezone."""
     return datetime.now(tz=ZoneInfo(tz_name))
 
 
-def now_iso(tz_name: str = "Asia/Shanghai") -> str:
+def now_iso(tz_name: str = "UTC") -> str:
     """Return current time as an ISO format string in the given timezone."""
     return now(tz_name).isoformat()
 

--- a/src/openclaw_ltk/config.py
+++ b/src/openclaw_ltk/config.py
@@ -71,7 +71,7 @@ class LtkConfig:
     diagnostics_log_path: Path = dataclasses.field(default=Path())
 
     # IANA timezone name used for timestamps.
-    timezone: str = "Asia/Shanghai"
+    timezone: str = "UTC"
 
     # Telegram chat ID for notifications; empty string means disabled.
     telegram_chat_id: str = ""
@@ -209,7 +209,7 @@ class LtkConfig:
             exec_approvals_path=_opt_path("LTK_EXEC_APPROVALS_PATH"),
             openclaw_config_path=_opt_path("LTK_OPENCLAW_CONFIG_PATH"),
             diagnostics_log_path=_opt_path("LTK_DIAGNOSTICS_LOG_PATH"),
-            timezone=_env("LTK_TIMEZONE") or "Asia/Shanghai",
+            timezone=_env("LTK_TIMEZONE") or "UTC",
             telegram_chat_id=_env("LTK_TELEGRAM_CHAT_ID") or "",
             timeout_seconds=_opt_int("LTK_TIMEOUT_SECONDS", 1800),
             silence_budget_minutes=_opt_int("LTK_SILENCE_BUDGET_MINUTES", 10),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,7 @@ class TestDefaultValues:
         """Default config constructed with a workspace should have correct defaults."""
         cfg = LtkConfig(workspace=Path("/tmp/ws"))
         assert cfg.workspace == Path("/tmp/ws")
-        assert cfg.timezone == "Asia/Shanghai"
+        assert cfg.timezone == "UTC"
         assert cfg.telegram_chat_id == ""
         assert cfg.timeout_seconds == 1800
         assert cfg.silence_budget_minutes == 10

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -12,7 +12,7 @@ from openclaw_ltk.memory import append_daily_memory_note, ensure_memory_files
 
 def test_ensure_memory_files_creates_index_and_daily_file(tmp_path: Path) -> None:
     config = LtkConfig(workspace=tmp_path)
-    now_local = datetime(2026, 3, 13, 9, 30, tzinfo=ZoneInfo("Asia/Shanghai"))
+    now_local = datetime(2026, 3, 13, 9, 30, tzinfo=ZoneInfo("UTC"))
 
     memory_index, daily_path = ensure_memory_files(config, now_local)
 
@@ -26,11 +26,11 @@ def test_ensure_memory_files_creates_index_and_daily_file(tmp_path: Path) -> Non
 
 def test_append_daily_memory_note_appends_custom_entry(tmp_path: Path) -> None:
     config = LtkConfig(workspace=tmp_path)
-    now_local = datetime(2026, 3, 14, 10, 15, tzinfo=ZoneInfo("Asia/Shanghai"))
+    now_local = datetime(2026, 3, 14, 10, 15, tzinfo=ZoneInfo("UTC"))
 
     daily_path = append_daily_memory_note(config, now_local, "Manual checkpoint")
 
     assert daily_path == tmp_path / "memory" / "2026-03-14.md"
     daily_text = daily_path.read_text(encoding="utf-8")
     assert "Manual checkpoint" in daily_text
-    assert "2026-03-14T10:15:00+08:00" in daily_text
+    assert "2026-03-14T10:15:00+00:00" in daily_text


### PR DESCRIPTION
## Summary
- Change default timezone from `Asia/Shanghai` to `UTC` in `config.py` (field default + `from_env` fallback) and `clock.py` (`now`/`now_iso` default parameter)
- Update corresponding test assertions in `test_config.py` and `test_memory.py`

Closes #15

## Test plan
- [x] pytest: 167 passed
- [x] ruff check: all passed
- [x] mypy --strict: no issues