### PR TITLE
docs: add wiki for loop job config, issue classification, CI gates

### DIFF
--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,12 @@
+# Wiki
+
+Operational documentation for the automated issue processing loop.
+
+## Pages
+
+- [Loop Job Configuration](loop-job-configuration.md) — Full prompt,
+  cron schedule, time zone mapping, and design rationale
+- [Issue Classification](issue-classification.md) — Priority order,
+  category definitions, and decision flow
+- [CI & Quality Gates](ci-quality-gates.md) — Local vs CI commands,
+  pre-commit hook, code review workflow, and TDD standards

--- a/docs/wiki/ci-quality-gates.md
+++ b/docs/wiki/ci-quality-gates.md
@@ -1,0 +1,131 @@
+# CI & Quality Gates
+
+Verification commands, hooks, and code review workflow used by the
+automated loop.
+
+## Verification Commands
+
+### Local (used by loop job)
+
+```bash
+.venv/bin/pytest -q
+.venv/bin/ruff check .
+.venv/bin/ruff format --check src/ tests/
+.venv/bin/mypy --strict src tests
+```
+
+### CI (`.github/workflows/ci.yml`)
+
+```bash
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/openclaw_ltk/ --strict
+uv run pytest --cov=openclaw_ltk tests/ -v
+```
+
+### Differences
+
+| Check | Local | CI | Impact |
+|-------|-------|----|--------|
+| ruff check | `.` (all files) | `src/ tests/` | Local is stricter (catches root-level files) |
+| mypy scope | `src tests` | `src/openclaw_ltk/` only | Local is stricter (also checks tests/) |
+| pytest | `-q` (quiet) | `--cov -v` (coverage + verbose) | Output format only |
+
+Local being stricter than CI is **by design**.  If local passes, CI will
+never fail on scope differences.
+
+## Pre-commit Hook
+
+File: `.claude/hooks/ruff-format.sh`
+
+A Claude Code `PreToolUse` hook that auto-formats staged Python files
+before `git commit`:
+
+1. Detects `git commit` in the Bash command.
+2. Finds staged `.py` files via `git diff --cached`.
+3. Runs `ruff format` on each file.
+4. Re-stages files that changed.
+
+Configuration in `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/ruff-format.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Why this hook exists
+
+Early in the project, all 5 initial PRs failed CI because
+`ruff format --check` caught pre-existing unformatted files.  The hook
+prevents this class of failure by auto-formatting before every commit.
+
+### Robustness
+
+- `jq` calls use `2>/dev/null || true` to prevent hook failures from
+  blocking non-git Bash commands.
+- `set -e` is used for early exit on unexpected errors, but all critical
+  paths have fallback guards.
+- If `ruff` is not found, the hook silently exits (no-op).
+
+## Code Review Workflow
+
+The loop handles code review comments with priority-based triage:
+
+| Priority | Type | Action |
+|----------|------|--------|
+| P0 | Critical bugs, security vulnerabilities | Must fix before merge |
+| P1 | Logic errors, incorrect behavior | Must fix before merge |
+| P2 | Code quality, naming, suggestions | Fix if clear and safe; report to user if uncertain |
+| P3 | Style preferences | Note but do not block merge |
+| P4 | Optional suggestions | Note but do not block merge |
+
+### Review sources
+
+- `gh api repos/.../pulls/N/reviews`: Formal review decisions (APPROVED,
+  CHANGES_REQUESTED, COMMENTED).
+- `gh api repos/.../pulls/N/comments`: Line-level review comments with
+  priority badges.
+
+### Merge criteria
+
+A PR is merge-ready when:
+
+1. All CI checks report SUCCESS.
+2. `reviewDecision` is not `CHANGES_REQUESTED`.
+3. `mergeable` is not `CONFLICTING`.
+4. No unresolved P0-P2 comments remain.
+
+Merge command: `gh pr merge <N> --squash --delete-branch`
+
+## TDD Standards
+
+The loop enforces "rocket-grade" TDD discipline:
+
+1. **Red**: Write a failing test that captures the expected behavior.
+2. **Verify red**: Run `pytest` to confirm the test fails for the right
+   reason.
+3. **Green**: Write the minimal implementation to make the test pass.
+4. **Verify green**: Run `pytest` to confirm the test passes.
+5. **Full suite**: Run all 4 verification commands before committing.
+
+Additional rules:
+
+- Every behavior change must have corresponding test coverage.
+- CLI command/output changes require README.md updates in the same PR.
+- One PR per issue.  Keep changes small and reviewable.
+- Follow AGENTS.md constraints: thin wrapper, stdlib-first, no speculative
+  abstractions.

--- a/docs/wiki/issue-classification.md
+++ b/docs/wiki/issue-classification.md
@@ -1,0 +1,99 @@
+# Issue Classification
+
+How the automated loop categorizes and prioritizes open issues.
+
+## Priority Order
+
+Issues are processed in milestone order, then by size within each
+milestone:
+
+```
+M0-stability > M1-issue-loop > M2-github-e2e > M3-release
+```
+
+Within each milestone: **Size S > Size M > Size L**.
+
+Issues without a Size label are evaluated by reading the issue body before
+assignment.
+
+## Classification Categories
+
+### Skip Entirely
+
+These issues are excluded from automated processing:
+
+| Issue | Reason |
+|-------|--------|
+| #3 | Meta vision/roadmap with multiple open-ended questions requiring human decisions |
+| #6 | External research report reference with no actionable code work |
+
+### Direct TDD
+
+Issues with concrete suggestions or clear acceptance criteria.  Implement
+directly using strict TDD:
+
+| Issue | Title | Milestone |
+|-------|-------|-----------|
+| #7 | Preflight bootstrap gap: init alone mistaken for preflight pass | M0 |
+| #13 | Patrol should escalate preflight PASS but state still stuck | M0 |
+| #18 | Unify diagnostics event model (Size L, may need Plan) | M0 |
+| #24 | Document incident/pitfall reporting workflow in README | M1 |
+| #26 | Implement `ltk report issue` command | M1 |
+| #31 | Add sanitization strategy for paths, tokens, and URLs | M1 |
+
+### Plan First
+
+Issues that are interconnected or require architectural decisions before
+implementation:
+
+| Issue Group | Title Pattern | Reason |
+|-------------|---------------|--------|
+| #8, #9, #10, #11, #12 | State-machine workflow improvements | Form a coherent group around stage-gated transitions.  Must respect AGENTS.md thin-wrapper constraint.  Plan should propose minimal state/command additions. |
+
+### RFC / Discussion
+
+Issues that describe future direction rather than immediate work:
+
+| Issue | Title | Action |
+|-------|-------|--------|
+| #23 | RFC: v0.4 auto-fetch issues and apply fixes | Read body to determine if actionable; if pure RFC, skip |
+
+### Other Implementable Issues
+
+Remaining issues by milestone.  Read issue body to determine approach:
+
+| Milestone | Issues |
+|-----------|--------|
+| M2 | #22 (contract tests), #25 (CodeQL/CI), #29 (GitHub API client), #30 (fake openclaw binary) |
+| M3 | #21 (release workflow), #27 (version tags), #28 (documentation), #32 (schema\_version) |
+
+## Decision Flow
+
+```
+Issue opened
+  |
+  +-- #3 or #6? --> SKIP
+  |
+  +-- Has open PR? --> SKIP (wait for PR to merge)
+  |
+  +-- Part of #8-#12 group? --> PLAN MODE (group architecture)
+  |
+  +-- Has Size label?
+  |     +-- S/M --> DIRECT TDD
+  |     +-- L
+  |           +-- AC clear? --> DIRECT TDD
+  |           +-- Needs arch decision? --> PLAN MODE
+  |
+  +-- No Size label --> READ BODY --> assess complexity --> assign category
+```
+
+## Notes
+
+- **"No AC" does not mean "skip"**: Many issues describe problems with
+  detailed "Suggested improvements" sections that serve as acceptance
+  criteria.  Always read the issue body before deciding.
+- **New issues**: Issues created after this classification was written
+  should be evaluated by reading their body.  Do not assume they fit
+  existing categories.
+- **Milestone labels**: Issues without milestone labels are treated as
+  lowest priority (after M3).

--- a/docs/wiki/loop-job-configuration.md
+++ b/docs/wiki/loop-job-configuration.md
@@ -1,0 +1,194 @@
+# Loop Job Configuration
+
+Automated issue processing loop for `xrf9268-hue/openclaw-long-task-kit`.
+This job runs inside a Claude Code session via `CronCreate` and auto-expires
+after 3 days.
+
+## Cron Schedule
+
+```
+*/30 2-19 * * 1-5
+```
+
+| Field | Value | Meaning |
+|-------|-------|---------|
+| Minute | `*/30` | Every 30 minutes |
+| Hour | `2-19` | UTC 02:00–19:59 |
+| Day of month | `*` | Every day |
+| Month | `*` | Every month |
+| Day of week | `1-5` | Monday–Friday |
+
+### Time Zone Mapping
+
+| Time Zone | Job Window | Peak (1x) Window |
+|-----------|------------|-------------------|
+| UTC | 02:00–19:59 | 12:00–18:00 |
+| Beijing (UTC+8) | 10:00–03:59(+1) | 20:00–02:00(+1) |
+| PT (PDT, UTC-7) | 19:00(prev)–12:59 | 05:00–11:00 |
+
+The job window is designed to **fully avoid** the Claude 1x peak period
+(weekdays 5–11am PT / 12–6pm GMT), maximizing 2x usage bonus.
+
+> **DST note**: During PST (November–March), peak shifts to Beijing
+> 21:00–03:00.  If recreating the job in winter, change the hour range to
+> `3-19` to avoid the 02:00–02:59 overlap.
+
+## Full Prompt
+
+```markdown
+## Automated Issue Processing Loop
+
+### Step 1: Process Open PRs (must clear all before Step 2)
+
+Run `gh pr list --repo xrf9268-hue/openclaw-long-task-kit --state open
+--json number,title,headRefName,statusCheckRollup,reviewDecision,mergeable`
+to check all open PRs:
+
+**A. CI failure ->** `gh run view` to check logs, switch to the branch,
+fix, push.
+
+**B. Code review handling (by priority):**
+- Fetch comments via `gh api repos/.../pulls/<N>/comments` and
+  `gh api repos/.../pulls/<N>/reviews`
+- **P0/P1 (bugs, security, logic errors) ->** Must fix, push update
+- **P2 (code quality, naming, suggestions) ->** Evaluate: if the change
+  is clear and safe, fix it; if it involves design decisions or
+  uncertainty, **report to user and skip the PR**
+- **P3/P4 (style preferences, optional suggestions) ->** Note but do not
+  block merge
+
+**C. Merge conflicts ->** Rebase onto main, push.
+
+**D. Merge-ready PR (all CI SUCCESS + reviewDecision not
+CHANGES_REQUESTED + no conflicts + no unresolved P0-P2 comments):**
+- `gh pr merge <N> --repo xrf9268-hue/openclaw-long-task-kit --squash
+  --delete-branch`
+- Clean up local branch, `git checkout main && git pull`
+
+**E. Process all PRs before entering Step 2.**
+
+### Step 2: Select Next Issue
+
+`git checkout main && git pull` to ensure latest.
+
+Run `gh issue list --repo xrf9268-hue/openclaw-long-task-kit --state open
+--json number,title,labels --limit 50`.
+
+**Exclude:** issues with existing open PRs, #3 (vision/roadmap),
+#6 (external research reference).
+
+**Sort by M0 > M1 > M2 > M3 priority, Size S > M > L.**
+For issues without a Size label, read the issue body
+(`gh issue view <N> --repo ...`) to assess complexity first.
+
+If no processable issues remain, report "all issues completed" or
+"remaining issues need human decision".
+
+### Step 3: Classify & Implement
+
+After reading the issue body, handle by category:
+
+**A. Issues with clear AC or concrete improvement suggestions
+(e.g. #7, #13, #18):**
+- Size S/M -> Direct TDD
+- Size L (clear AC) -> Direct TDD
+- Size L (needs architecture decisions) -> Plan mode, pause for user
+  confirmation
+
+**B. Strongly related issue groups (e.g. #8-#12 state machine):**
+- Do not implement individually; assess overall architectural impact
+- Enter Plan mode, design a thin-wrapper solution per AGENTS.md
+  constraints
+- Pause for user confirmation
+
+**C. Quality requirements (rocket-grade standards):**
+- Strict TDD: write failing test -> verify red -> minimal implementation
+  -> verify green
+- Every behavior change must have test coverage
+- Update README.md when adding CLI commands or changing output
+- Follow all AGENTS.md constraints: thin wrapper, stdlib-first, strict
+  mypy, no speculative abstractions
+- Changes must be small and reviewable; one PR does one thing
+
+### Step 4: Verify & Submit
+
+Full check suite (all must pass):
+
+    .venv/bin/pytest -q
+    .venv/bin/ruff check .
+    .venv/bin/ruff format --check src/ tests/
+    .venv/bin/mypy --strict src tests
+
+After passing, commit and create PR (body includes `Closes #<number>`).
+
+**One issue per loop iteration. Wait for next cycle to verify CI/review.**
+
+Report results: which PRs were merged, which new PR was created, which
+reviews were fixed, or which reviews need user decision.
+```
+
+## Design Rationale
+
+### Why 30-minute intervals?
+
+- **Sufficient for Size S/M issues**: Most small issues complete within a
+  single 30-minute window (TDD cycle + verification + PR creation).
+- **Natural checkpoint for CI**: After creating a PR, the next iteration
+  checks whether CI passed and reviews arrived.
+- **Prevents runaway work**: Forces a stop-and-check cadence instead of
+  continuous implementation.
+
+### Why one issue per iteration?
+
+- **Avoids context contamination**: Each issue gets a clean `main` base.
+- **Enables review feedback loops**: PRs get time for CI and reviewer
+  comments before the next issue starts.
+- **Keeps PRs small and reviewable**: Aligns with AGENTS.md "small and
+  reviewable" requirement.
+
+### Why process PRs before new issues?
+
+- **Prevents PR pile-up**: Without this rule, the loop would keep creating
+  PRs without merging, leading to merge conflicts and stale branches.
+- **Review-first culture**: Code review feedback is more valuable fresh;
+  addressing it promptly improves code quality.
+- **Clean main branch**: Merging before starting new work ensures each
+  issue builds on the latest integrated code.
+
+### Why priority-based code review handling?
+
+Prior experience showed two failure modes:
+
+1. **Blind compliance**: Treating every bot comment as a blocking issue led
+   to unnecessary churn on P3/P4 style suggestions.
+2. **Blind ignore**: Skipping reviews entirely caused real bugs (P1) to
+   ship, e.g. incorrect remediation guidance in README.
+
+The P0-P4 classification balances thoroughness with pragmatism:
+
+- P0/P1 must be fixed (safety).
+- P2 requires judgment (report to user if uncertain).
+- P3/P4 are non-blocking (note but don't delay).
+
+### Why exclude only #3 and #6?
+
+Early versions of the loop excluded issues #7-#13 as "discussion-only".
+This was corrected: these issues contain **concrete improvement
+suggestions** that serve as acceptance criteria.  Only two issues are truly
+non-implementable:
+
+- **#3**: Meta vision/roadmap with open-ended product questions.
+- **#6**: External research report reference with no code work.
+
+### Why Plan mode for #8-#12?
+
+Issues #8-#12 form a coherent group around state-machine workflow
+improvements (repair lanes, transition guards, automatic handoffs).
+Implementing them piecemeal would risk:
+
+- Contradictory designs across PRs.
+- Violating AGENTS.md "thin wrapper" constraint by accidentally building a
+  workflow engine.
+- Rework when later issues invalidate earlier implementations.
+
+Plan mode forces upfront architectural alignment before any code is written.


### PR DESCRIPTION
## Summary

- Add `docs/wiki/` with operational documentation for the automated issue processing loop
- **Loop Job Configuration**: full prompt text, cron schedule (`*/30 2-19 * * 1-5`), time zone mapping (UTC/Beijing/PT), DST considerations, and design rationale for all key decisions
- **Issue Classification**: M0>M1>M2>M3 priority order, category definitions (Skip/Direct TDD/Plan First/RFC), decision flow, notes on edge cases
- **CI & Quality Gates**: local vs CI command comparison, pre-commit hook design and robustness, P0-P4 code review triage workflow, TDD standards

## Why docs/wiki/ instead of GitHub Wiki?

GitHub Wiki requires manual web UI initialization and browser authentication. Storing in-repo provides version control, PR review, and CI integration. These pages can be synced to GitHub Wiki later if desired.

## Test plan

- [x] `pytest` passes (171 tests)
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy --strict` passes
- [ ] Verify markdown renders correctly on GitHub