### PR TITLE
feat: add preflight_status marker and post-save validation to init

### DIFF
--- a/src/openclaw_ltk/commands/init.py
+++ b/src/openclaw_ltk/commands/init.py
@@ -327,10 +327,16 @@ def init_cmd(
     click.echo("       Preflight passed.")
 
     # ------------------------------------------------------------------ #
-    # Step 8 — Write cron job IDs back into state and save                #
+    # Step 8 — Write cron job IDs, preflight results, and save            #
     # ------------------------------------------------------------------ #
     click.echo("[8/10] Writing state file.")
     data["control_plane"]["cron_jobs"] = cron_jobs
+    data["preflight_status"] = "passed" if result.valid else "failed"
+    data["preflight"] = {
+        "overall": "PASS" if result.valid else "FAIL",
+        "errors": result.errors,
+        "warnings": result.warnings,
+    }
 
     try:
         config.state_dir.mkdir(parents=True, exist_ok=True)
@@ -342,6 +348,23 @@ def init_cmd(
         sys.exit(2)
     except OSError as exc:
         click.echo(f"ERROR: Failed to write state file: {exc}")
+        sys.exit(2)
+
+    # Post-save validation: re-read the file to verify disk integrity.
+    click.echo("       Post-save validation: re-reading state file.")
+    try:
+        reloaded = state_file.load()
+        reload_result = validate_state(reloaded)
+        if not reload_result.valid:
+            click.echo(
+                "ERROR: Post-save validation failed — state file on disk is invalid:"
+            )
+            for err in reload_result.errors:
+                click.echo(f"  {err}")
+            sys.exit(2)
+        click.echo("       Post-save validation passed.")
+    except (StateFileError, OSError) as exc:
+        click.echo(f"ERROR: Post-save validation failed: {exc}")
         sys.exit(2)
 
     # ------------------------------------------------------------------ #

--- a/src/openclaw_ltk/commands/preflight.py
+++ b/src/openclaw_ltk/commands/preflight.py
@@ -273,6 +273,7 @@ def preflight_cmd(state_path: str, write_back: bool) -> None:
     if write_back:
         try:
             with sf.locked_update() as data:
+                data["preflight_status"] = "passed" if overall == "PASS" else "failed"
                 data["preflight"] = {
                     "overall": overall,
                     "checks": {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -150,6 +150,35 @@ class TestRunInitPreflight:
         assert len(result.errors) > 0
 
 
+class TestInitPreflightStatus:
+    """Issue #7: init should record preflight_status in state."""
+
+    def test_state_has_preflight_status(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        _run_init(runner, tmp_path)
+        state_files = list((tmp_path / "tasks" / "state").glob("*.json"))
+        data = json.loads(state_files[0].read_text())
+        assert data["preflight_status"] == "passed"
+
+    def test_state_has_preflight_results(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        _run_init(runner, tmp_path)
+        state_files = list((tmp_path / "tasks" / "state").glob("*.json"))
+        data = json.loads(state_files[0].read_text())
+        assert "preflight" in data
+        assert data["preflight"]["overall"] == "PASS"
+
+
+class TestInitPostSaveValidation:
+    """Issue #7: init should re-read saved state to verify disk integrity."""
+
+    def test_output_confirms_post_save_validation(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = _run_init(runner, tmp_path)
+        assert result.exit_code == 0
+        assert "post-save" in result.output.lower()
+
+
 class TestInitPreventOverwrite:
     def test_second_run_fails(self, tmp_path: Path) -> None:
         runner = CliRunner()

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -331,3 +331,48 @@ class TestPreflightCmd:
         checks = written["preflight"]["checks"]
         assert checks["gateway-health"]["source"] == "openclaw health --json"
         assert checks["exec-approvals"]["source"] == str(config.exec_approvals_path)
+
+    def test_write_back_sets_preflight_status(
+        self, tmp_path: Path, sample_state_data: dict[str, Any]
+    ) -> None:
+        """Issue #7: --write-back should set preflight_status marker."""
+        sample_state_data["control_plane"] = {"cron_jobs": []}
+        state_file = _write_state(tmp_path, sample_state_data)
+
+        config = LtkConfig(
+            workspace=tmp_path,
+            openclaw_state_dir=tmp_path / "host-state",
+        )
+        inject_heartbeat_entry(
+            config.heartbeat_path, "t", "T", "active", "G", "2026-01-01"
+        )
+        config.pointer_path.parent.mkdir(parents=True, exist_ok=True)
+        config.pointer_path.write_text('{"task_id": "t1"}', encoding="utf-8")
+        config.exec_approvals_path.parent.mkdir(parents=True, exist_ok=True)
+        config.exec_approvals_path.write_text("{}", encoding="utf-8")
+
+        mock_cron = MagicMock()
+        mock_cron.list_jobs.return_value = []
+        mock_openclaw = MagicMock()
+        mock_openclaw.health.return_value = {"ok": True}
+
+        runner = CliRunner()
+        with (
+            patch("openclaw_ltk.commands.preflight.CronClient", return_value=mock_cron),
+            patch(
+                "openclaw_ltk.commands.preflight.OpenClawClient",
+                return_value=mock_openclaw,
+            ),
+        ):
+            result = runner.invoke(
+                main,
+                ["preflight", "--state", str(state_file), "--write-back"],
+                env={
+                    "LTK_WORKSPACE": str(tmp_path),
+                    "OPENCLAW_STATE_DIR": str(config.openclaw_state_dir),
+                },
+            )
+
+        assert result.exit_code == 0
+        written = json.loads(state_file.read_text(encoding="utf-8"))
+        assert written["preflight_status"] == "passed"


### PR DESCRIPTION
## Summary

- `ltk init` now records `preflight_status` ("passed"/"failed") and full `preflight` results in the state JSON, closing the bootstrap gap where init could be mistaken for preflight pass
- `ltk init` performs post-save validation by re-reading the state file from disk and validating it, catching disk corruption immediately
- `ltk preflight --write-back` also writes `preflight_status` marker for consistency

Closes #7

## Changes

- `src/openclaw_ltk/commands/init.py`: Write `preflight_status` and `preflight` dict into state before save; add post-save re-read + validate step
- `src/openclaw_ltk/commands/preflight.py`: Add `preflight_status` to `--write-back` output
- `tests/test_init.py`: 3 new tests (preflight_status, preflight results, post-save validation output)
- `tests/test_preflight.py`: 1 new test (write-back sets preflight_status)

## Test plan

- [x] 175 tests pass
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy --strict` passes
- [x] TDD: wrote 4 failing tests first, verified red, then implemented