### PR TITLE
feat: add sanitization utility for paths, tokens, and URLs

### DIFF
--- a/src/openclaw_ltk/sanitize.py
+++ b/src/openclaw_ltk/sanitize.py
@@ -6,10 +6,10 @@ import re
 from dataclasses import dataclass
 
 # Matches /home/<user> or /Users/<user>
-_HOME_PATH_RE = re.compile(r"/(?:home|Users)/\w+")
+_HOME_PATH_RE = re.compile(r"/(?:home|Users)/[\w.\-]+")
 
 # Matches Bearer <token>
-_BEARER_RE = re.compile(r"(Bearer\s+)\S+")
+_BEARER_RE = re.compile(r"(Bearer\s+)\S+", re.IGNORECASE)
 
 # Matches known secret-like key=value or key: value patterns
 _KEY_VALUE_RE = re.compile(

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -25,6 +25,18 @@ class TestRedactHomePaths:
         assert "~/a.py" in result
         assert "~/b.py" in result
 
+    def test_username_with_hyphen(self) -> None:
+        text = "/home/john-doe/projects/ltk"
+        result = sanitize(text)
+        assert "/home/john-doe" not in result
+        assert "~/projects/ltk" in result
+
+    def test_username_with_dot(self) -> None:
+        text = "/Users/j.smith/.config/openclaw"
+        result = sanitize(text)
+        assert "/Users/j.smith" not in result
+        assert "~/.config/openclaw" in result
+
     def test_preserves_non_home_paths(self) -> None:
         text = "Binary at /usr/local/bin/openclaw"
         result = sanitize(text)
@@ -43,6 +55,11 @@ class TestRedactTokens:
         result = sanitize(text)
         assert "sk-ant-api03-abc123xyz" not in result
         assert "Bearer" in result
+
+    def test_bearer_case_insensitive(self) -> None:
+        text = "authorization: bearer sk-ant-secret"
+        result = sanitize(text)
+        assert "sk-ant-secret" not in result
 
     def test_github_pat(self) -> None:
         text = "token: ghp_1234567890abcdef"


### PR DESCRIPTION
## Summary
- Creates `src/openclaw_ltk/sanitize.py` with configurable `SanitizeConfig` and `sanitize()` function
- Redacts home directory paths (`/home/user/...` → `~/...`), Bearer/API tokens, key=value secrets, and URL credentials
- 17 unit tests covering all sanitization patterns, edge cases, and disable toggles
- Integration with `ltk report issue` deferred to #26

## Test plan
- [x] 208 tests pass (191 existing + 17 new)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy` clean (only pre-existing `lock.py:81` error)

Closes #31