### PR TITLE
feat: add ltk report issue command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The current CLI surface matches `ltk --help`:
 - `notify`: render wrapper-level task summaries or Telegram preview payloads
 - `pointer`: manage the active task pointer JSON file
 - `preflight`: validate state, files, approvals, cron coverage, and gateway health
+- `report issue`: generate a Markdown issue report from task state (sanitized by default)
 - `resume`: rerun preflight, refresh bootstrap files, append a memory note, and
   surface continuation/exhaustion policy results
 - `status`: print task status plus deadman, continuation, exhaustion, and validation

--- a/src/openclaw_ltk/cli.py
+++ b/src/openclaw_ltk/cli.py
@@ -25,6 +25,7 @@ from openclaw_ltk.commands.memory import memory_cmd  # noqa: E402
 from openclaw_ltk.commands.notify import notify_cmd  # noqa: E402
 from openclaw_ltk.commands.pointer import pointer_cmd  # noqa: E402
 from openclaw_ltk.commands.preflight import preflight_cmd  # noqa: E402
+from openclaw_ltk.commands.report import report_cmd  # noqa: E402
 from openclaw_ltk.commands.resume import resume_cmd  # noqa: E402
 from openclaw_ltk.commands.status import status_cmd  # noqa: E402
 from openclaw_ltk.commands.watchdog import watchdog_cmd  # noqa: E402
@@ -40,6 +41,7 @@ main.add_command(logs_cmd, "logs")
 main.add_command(memory_cmd, "memory")
 main.add_command(notify_cmd, "notify")
 main.add_command(pointer_cmd, "pointer")
+main.add_command(report_cmd, "report")
 main.add_command(resume_cmd, "resume")
 main.add_command(status_cmd, "status")
 main.add_command(watchdog_cmd, "watchdog")

--- a/src/openclaw_ltk/commands/report.py
+++ b/src/openclaw_ltk/commands/report.py
@@ -1,0 +1,41 @@
+"""Report generation commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from openclaw_ltk.errors import LtkError
+from openclaw_ltk.report import render_issue_report
+from openclaw_ltk.state import StateFile
+
+
+@click.group("report")
+def report_cmd() -> None:
+    """Generate reports from task data."""
+
+
+@report_cmd.command("issue")
+@click.option("--state", "state_path", required=True, help="Path to state file")
+@click.option("--output", "output_path", default=None, help="Write report to file")
+@click.option("--no-sanitize", is_flag=True, help="Disable sensitive data redaction")
+def report_issue_cmd(
+    state_path: str, output_path: str | None, no_sanitize: bool
+) -> None:
+    """Generate a Markdown issue report from task state."""
+    try:
+        state = StateFile(Path(state_path).expanduser().resolve()).load()
+    except LtkError as exc:
+        click.echo(f"ERROR: {exc.message}", err=True)
+        raise SystemExit(2) from exc
+
+    report = render_issue_report(state, sanitize_output=not no_sanitize)
+
+    if output_path:
+        out = Path(output_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(report, encoding="utf-8")
+        click.echo(f"Report written to {out}")
+    else:
+        click.echo(report)

--- a/src/openclaw_ltk/report.py
+++ b/src/openclaw_ltk/report.py
@@ -1,0 +1,119 @@
+"""Issue report rendering — generates Markdown from task state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openclaw_ltk.policies.continuation import (
+    format_continuation_summary,
+    should_continue,
+)
+from openclaw_ltk.policies.deadman import check_deadman
+from openclaw_ltk.policies.exhaustion import (
+    evaluate_exhaustion,
+    format_exhaustion_summary,
+)
+from openclaw_ltk.policies.progression import (
+    check_progression_stall,
+    format_progression_summary,
+)
+from openclaw_ltk.sanitize import sanitize
+from openclaw_ltk.schema import validate_state
+
+
+def render_issue_report(
+    state: dict[str, Any],
+    *,
+    sanitize_output: bool = True,
+) -> str:
+    """Render a Markdown issue report from task state data."""
+    task_id = str(state.get("task_id", "unknown"))
+    title = str(state.get("title", "untitled"))
+    status = str(state.get("status", "unknown"))
+    phase = str(state.get("phase", "unknown"))
+    goal = str(state.get("goal", ""))
+    updated_at = str(state.get("updated_at", ""))
+    error_count = state.get("error_count", 0)
+
+    cwp = state.get("current_work_package") or {}
+    cwp_id = str(cwp.get("id", "-"))
+    cwp_goal = str(cwp.get("goal", "-"))
+    cwp_done_when = str(cwp.get("done_when", "-"))
+    blockers = cwp.get("blockers", [])
+
+    # Policy diagnostics.
+    continuation = should_continue(state)
+    exhaustion = evaluate_exhaustion(state)
+    deadman = check_deadman(state)
+    progression = check_progression_stall(state)
+    validation = validate_state(state)
+
+    # Notes.
+    notes = state.get("notes", [])
+
+    sections: list[str] = []
+
+    # Header.
+    sections.append(f"# Issue Report: {title}")
+    sections.append("")
+
+    # Task metadata table.
+    sections.append("## Task Metadata")
+    sections.append("")
+    sections.append("| Field | Value |")
+    sections.append("|-------|-------|")
+    sections.append(f"| Task ID | `{task_id}` |")
+    sections.append(f"| Status | {status} |")
+    sections.append(f"| Phase | {phase} |")
+    sections.append(f"| Goal | {goal} |")
+    sections.append(f"| Updated | {updated_at} |")
+    sections.append(f"| Error Count | {error_count} |")
+    sections.append("")
+
+    # Work package.
+    sections.append("## Current Work Package")
+    sections.append("")
+    sections.append(f"- **ID:** {cwp_id}")
+    sections.append(f"- **Goal:** {cwp_goal}")
+    sections.append(f"- **Done when:** {cwp_done_when}")
+    if blockers:
+        sections.append(f"- **Blockers:** {', '.join(str(b) for b in blockers)}")
+    sections.append("")
+
+    # Diagnostics.
+    sections.append("## Diagnostics")
+    sections.append("")
+    sections.append(f"- {format_continuation_summary(continuation)}")
+    sections.append(f"- {format_exhaustion_summary(exhaustion)}")
+    sections.append(f"- Deadman: {deadman.status} — {deadman.message}")
+    sections.append(f"- {format_progression_summary(progression)}")
+    sections.append("")
+
+    # Validation.
+    val_label = "valid" if validation.valid else "INVALID"
+    sections.append("## Validation")
+    sections.append("")
+    sections.append(
+        f"**{val_label}** ({len(validation.errors)} errors, "
+        f"{len(validation.warnings)} warnings)"
+    )
+    if validation.errors:
+        sections.append("")
+        for err in validation.errors:
+            sections.append(f"- {err}")
+    sections.append("")
+
+    # Notes.
+    if notes:
+        sections.append("## Notes")
+        sections.append("")
+        for note in notes:
+            sections.append(f"- {note}")
+        sections.append("")
+
+    report = "\n".join(sections)
+
+    if sanitize_output:
+        report = sanitize(report)
+
+    return report

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,112 @@
+"""Tests for ltk report issue command and rendering."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+
+from openclaw_ltk.cli import main
+from openclaw_ltk.report import render_issue_report
+
+
+class TestRenderIssueReport:
+    def test_contains_task_metadata(self, sample_state_data: dict[str, Any]) -> None:
+        md = render_issue_report(sample_state_data)
+        assert sample_state_data["task_id"] in md
+        assert sample_state_data["title"] in md
+        assert sample_state_data["status"] in md
+        assert sample_state_data["phase"] in md
+        assert sample_state_data["goal"] in md
+
+    def test_contains_work_package(self, sample_state_data: dict[str, Any]) -> None:
+        md = render_issue_report(sample_state_data)
+        wp = sample_state_data["current_work_package"]
+        assert wp["id"] in md
+        assert wp["goal"] in md
+
+    def test_contains_policy_diagnostics(
+        self, sample_state_data: dict[str, Any]
+    ) -> None:
+        md = render_issue_report(sample_state_data)
+        assert "Continuation" in md or "continuation" in md.lower()
+        assert "Exhaustion" in md or "exhaustion" in md.lower()
+
+    def test_sanitizes_paths_by_default(
+        self, sample_state_data: dict[str, Any]
+    ) -> None:
+        sample_state_data["notes"] = ["/home/yvan/secret/file.py"]
+        md = render_issue_report(sample_state_data)
+        assert "/home/yvan" not in md
+
+    def test_no_sanitize_preserves_paths(
+        self, sample_state_data: dict[str, Any]
+    ) -> None:
+        sample_state_data["notes"] = ["/home/yvan/secret/file.py"]
+        md = render_issue_report(sample_state_data, sanitize_output=False)
+        assert "/home/yvan" in md
+
+    def test_includes_error_count(self, sample_state_data: dict[str, Any]) -> None:
+        sample_state_data["error_count"] = 3
+        md = render_issue_report(sample_state_data)
+        assert "3" in md
+
+    def test_output_is_markdown(self, sample_state_data: dict[str, Any]) -> None:
+        md = render_issue_report(sample_state_data)
+        assert md.startswith("# ")
+
+
+def _write_state(tmp_path: Path, data: dict[str, Any]) -> Path:
+    state_dir = tmp_path / "tasks" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    sf = state_dir / "test.json"
+    sf.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return sf
+
+
+class TestReportIssueCmd:
+    def test_stdout_output(
+        self, tmp_path: Path, sample_state_data: dict[str, Any]
+    ) -> None:
+        state_file = _write_state(tmp_path, sample_state_data)
+        runner = CliRunner()
+        result = runner.invoke(main, ["report", "issue", "--state", str(state_file)])
+        assert result.exit_code == 0
+        assert sample_state_data["task_id"] in result.output
+        assert result.output.startswith("# ")
+
+    def test_file_output(
+        self, tmp_path: Path, sample_state_data: dict[str, Any]
+    ) -> None:
+        state_file = _write_state(tmp_path, sample_state_data)
+        out_file = tmp_path / "report.md"
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["report", "issue", "--state", str(state_file), "--output", str(out_file)],
+        )
+        assert result.exit_code == 0
+        content = out_file.read_text(encoding="utf-8")
+        assert sample_state_data["task_id"] in content
+
+    def test_no_sanitize_flag(
+        self, tmp_path: Path, sample_state_data: dict[str, Any]
+    ) -> None:
+        sample_state_data["notes"] = ["/home/yvan/secret/file.py"]
+        state_file = _write_state(tmp_path, sample_state_data)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["report", "issue", "--state", str(state_file), "--no-sanitize"],
+        )
+        assert result.exit_code == 0
+        assert "/home/yvan" in result.output
+
+    def test_missing_state_file(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["report", "issue", "--state", str(tmp_path / "nope.json")]
+        )
+        assert result.exit_code == 2


### PR DESCRIPTION
## Summary
- New `ltk report issue --state <path>` command generates Markdown issue reports
- Report includes task metadata, work package, policy diagnostics (continuation, exhaustion, deadman, progression), and validation results
- Sensitive data (home paths, tokens, URL credentials) sanitized by default; `--no-sanitize` to disable
- `--output <file>` writes to file instead of stdout
- 11 new tests (7 rendering + 4 CLI)
- README.md updated with new command

## Test plan
- [x] 222 tests pass (211 existing + 11 new)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy` clean (only pre-existing `lock.py:81` error)

Closes #26