### PR TITLE
ci: add CodeQL, dependency audit, pin Action SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
       - run: uv sync
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
@@ -19,8 +22,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
       - run: uv sync
       - run: uv run mypy src/openclaw_ltk/ --strict
 
@@ -30,9 +33,17 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync
       - run: uv run pytest --cov=openclaw_ltk tests/ -v
+
+  dependency-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
+      - run: uv sync
+      - run: uv run pip-audit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,27 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"  # Weekly Monday 06:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@603b797f8b14b413fe025cd935a91c16c4782713  # v3
+        with:
+          languages: python
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@603b797f8b14b413fe025cd935a91c16c4782713  # v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,5 @@ dev = [
     "pytest-cov>=4.0",
     "mypy>=1.0",
     "ruff>=0.4",
+    "pip-audit>=2.7",
 ]


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions by commit SHA (prevents supply chain attacks via mutable tags)
- Add CodeQL analysis workflow for Python static security analysis (runs on PR/push + weekly Monday 06:00 UTC)
- Add `pip-audit` dependency audit step to CI pipeline
- Add `pip-audit>=2.7` to dev dependencies

## Pinned SHAs
| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v4 | `34e11487...` |
| `astral-sh/setup-uv` | v4 | `38f3f104...` |
| `github/codeql-action/init` | v3 | `603b797f...` |
| `github/codeql-action/analyze` | v3 | `603b797f...` |

## Test plan
- [x] 222 existing tests pass (no code changes)
- [x] CI workflow syntax validated
- [ ] CodeQL and dependency-audit jobs pass on first run (new CI jobs)

Closes #25