### PR TITLE
feat: add fake openclaw binary builder for contract testing

### DIFF
--- a/tests/fake_openclaw.py
+++ b/tests/fake_openclaw.py
@@ -76,13 +76,21 @@ class FakeOpenClaw:
         Returns the path to the script.
         """
         cases: list[str] = []
-        for key, (response, rc) in self._routes.items():
+        # Sort routes: longer (more specific) keys first so they match
+        # before shorter wildcard patterns in the bash case statement.
+        sorted_routes = sorted(
+            self._routes.items(), key=lambda kv: len(kv[0]), reverse=True
+        )
+        for key, (response, rc) in sorted_routes:
             if response is None:
                 stdout_line = ""
             elif isinstance(response, str):
                 stdout_line = f"echo {json.dumps(response)}"
             else:
-                stdout_line = f"echo '{json.dumps(response)}'"
+                # Use heredoc to avoid single-quote escaping issues
+                # (e.g. JSON containing apostrophes).
+                encoded = json.dumps(response)
+                stdout_line = f"cat <<'FAKEJSON'\n{encoded}\nFAKEJSON"
             pattern = self._key_to_pattern(key)
             cases.append(f"  {pattern})\n    {stdout_line}\n    exit {rc}\n    ;;")
 

--- a/tests/test_fake_openclaw.py
+++ b/tests/test_fake_openclaw.py
@@ -101,6 +101,40 @@ class TestFakeOpenClawBuild:
         data = json.loads(result.stdout)
         assert "service" in data
 
+    def test_json_with_apostrophe(self, tmp_path: Path) -> None:
+        """P1: JSON containing apostrophes must not break bash quoting."""
+        fake = FakeOpenClaw(tmp_path / "openclaw")
+        fake.register("health --json", {"msg": "it's down", "ok": False})
+        fake.build()
+        result = subprocess.run(
+            [str(fake.path), "health", "--json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["msg"] == "it's down"
+
+    def test_custom_route_overrides_wildcard_default(self, tmp_path: Path) -> None:
+        """P2: Specific custom route must take priority over default wildcard."""
+        fake = FakeOpenClaw(tmp_path / "openclaw")
+        fake.register(
+            "cron remove job-1 --json",
+            {"error": "not found"},
+            exit_code=1,
+        )
+        fake.build()
+        result = subprocess.run(
+            [str(fake.path), "cron", "remove", "job-1", "--json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1
+        data = json.loads(result.stdout)
+        assert data["error"] == "not found"
+
 
 class TestFakeOpenClawIntegration:
     """Use the fake binary with real CronClient/OpenClawClient."""


### PR DESCRIPTION
## Summary
- Add `FakeOpenClaw` test helper that generates a configurable bash script as a stand-in for the real `openclaw` binary
- Default responses for `health`, `gateway status`, `doctor`, `cron list/add/remove/disable`
- Custom response payloads (dict/list → JSON, str → raw), custom exit codes
- Integration tests verify it works with real `CronClient` and `OpenClawClient`
- Docstring documents how to extend for new commands

## Test plan
- [x] 10 new tests (executable creation, default/custom responses, error scenarios, client integration)
- [x] Full suite (265 tests) passes
- [x] ruff check + format clean
- [x] mypy strict clean (pre-existing lock.py issue only)

Closes #30