### PR TITLE
feat: add version tags to HEARTBEAT/BOOT/AGENTS injection blocks

### DIFF
--- a/src/openclaw_ltk/generators/heartbeat_entry.py
+++ b/src/openclaw_ltk/generators/heartbeat_entry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from openclaw_ltk import __version__
 from openclaw_ltk.state import atomic_write_text
 
 # ---------------------------------------------------------------------------
@@ -13,7 +14,7 @@ from openclaw_ltk.state import atomic_write_text
 
 _ENTRY_TEMPLATE = """\
 ## LTK: {task_id}
-<!-- ltk:meta task_id={task_id} status={status} -->
+<!-- ltk:meta task_id={task_id} status={status} version={version} -->
 - **Task**: {title}
 - **Status**: {status}
 - **Updated**: {updated_at}
@@ -38,6 +39,7 @@ def generate_entry(
         status=status,
         goal=goal,
         updated_at=updated_at,
+        version=__version__,
     )
 
 
@@ -53,6 +55,7 @@ def _block_pattern(task_id: str) -> re.Pattern[str]:
     between the opening heading and the closing comment (inclusive).
     """
     escaped = re.escape(task_id)
+    # Match blocks with or without version= attribute (backward compatible).
     return re.compile(
         rf"^## LTK: {escaped}\n.*?<!-- ltk:end -->",
         re.MULTILINE | re.DOTALL,

--- a/src/openclaw_ltk/generators/workspace_bootstrap.py
+++ b/src/openclaw_ltk/generators/workspace_bootstrap.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from openclaw_ltk import __version__
 from openclaw_ltk.generators.agents_directive import generate_agents_directive
 from openclaw_ltk.generators.boot_entry import generate_boot_entry
 from openclaw_ltk.state import atomic_write_text
@@ -13,8 +14,10 @@ from openclaw_ltk.state import atomic_write_text
 
 def _block_pattern(kind: str, task_id: str) -> re.Pattern[str]:
     escaped = re.escape(task_id)
+    # Match blocks with or without version= attribute (backward compatible).
     return re.compile(
-        rf"^<!-- ltk:{kind} task_id={escaped} -->\n.*?<!-- ltk:{kind}:end -->",
+        rf"^<!-- ltk:{kind} task_id={escaped}(?: version=\S+)? -->\n"
+        rf".*?<!-- ltk:{kind}:end -->",
         re.MULTILINE | re.DOTALL,
     )
 
@@ -54,7 +57,7 @@ def inject_boot_entry(
     )
     block = "\n".join(
         [
-            f"<!-- ltk:boot task_id={task_id} -->",
+            f"<!-- ltk:boot task_id={task_id} version={__version__} -->",
             body,
             "<!-- ltk:boot:end -->",
         ]
@@ -75,7 +78,7 @@ def inject_agents_directive(
     )
     block = "\n".join(
         [
-            f"<!-- ltk:agents task_id={task_id} -->",
+            f"<!-- ltk:agents task_id={task_id} version={__version__} -->",
             body.rstrip("\n"),
             "<!-- ltk:agents:end -->",
         ]

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -283,3 +283,82 @@ class TestInjectBootEntry:
         assert text.count("Recovery: task-1") == 1
         assert "/tmp/two.json" in text
         assert "# Boot Notes" in text
+
+
+# ---------------------------------------------------------------------------
+# Version tags in injection blocks (Issue #27)
+# ---------------------------------------------------------------------------
+
+
+class TestVersionTagHeartbeat:
+    def test_entry_contains_version(self) -> None:
+        entry = generate_entry(
+            task_id="t1",
+            title="T",
+            status="active",
+            goal="G",
+            updated_at="2026-01-01",
+        )
+        assert "version=0.1.0" in entry
+
+    def test_inject_replaces_old_block_without_version(self, tmp_path: Path) -> None:
+        """Old blocks (no version tag) must be matched and replaced."""
+        hb = tmp_path / "HEARTBEAT.md"
+        old_block = (
+            "## LTK: t1\n"
+            "<!-- ltk:meta task_id=t1 status=active -->\n"
+            "- **Task**: T\n"
+            "<!-- ltk:end -->"
+        )
+        hb.write_text(old_block + "\n", encoding="utf-8")
+        inject_heartbeat_entry(hb, "t1", "T", "done", "G", "2026-01-02")
+        text = hb.read_text(encoding="utf-8")
+        assert text.count("## LTK: t1") == 1
+        assert "version=0.1.0" in text
+        assert "done" in text
+
+
+class TestVersionTagBoot:
+    def test_boot_block_contains_version(self, tmp_path: Path) -> None:
+        boot = tmp_path / "BOOT.md"
+        inject_boot_entry(
+            boot,
+            task_id="t1",
+            title="T",
+            goal="G",
+            state_path="/s.json",
+        )
+        text = boot.read_text(encoding="utf-8")
+        assert "version=0.1.0" in text
+
+    def test_replaces_old_block_without_version(self, tmp_path: Path) -> None:
+        boot = tmp_path / "BOOT.md"
+        old_block = "<!-- ltk:boot task_id=t1 -->\nbody\n<!-- ltk:boot:end -->"
+        boot.write_text(old_block + "\n", encoding="utf-8")
+        inject_boot_entry(
+            boot,
+            task_id="t1",
+            title="T",
+            goal="G",
+            state_path="/s.json",
+        )
+        text = boot.read_text(encoding="utf-8")
+        assert text.count("ltk:boot task_id=t1") == 1
+        assert "version=0.1.0" in text
+
+
+class TestVersionTagAgents:
+    def test_agents_block_contains_version(self, tmp_path: Path) -> None:
+        agents = tmp_path / "AGENTS.md"
+        inject_agents_directive(agents, "t1", "/s.json")
+        text = agents.read_text(encoding="utf-8")
+        assert "version=0.1.0" in text
+
+    def test_replaces_old_block_without_version(self, tmp_path: Path) -> None:
+        agents = tmp_path / "AGENTS.md"
+        old_block = "<!-- ltk:agents task_id=t1 -->\nbody\n<!-- ltk:agents:end -->"
+        agents.write_text(old_block + "\n", encoding="utf-8")
+        inject_agents_directive(agents, "t1", "/s.json")
+        text = agents.read_text(encoding="utf-8")
+        assert text.count("ltk:agents task_id=t1") == 1
+        assert "version=0.1.0" in text


### PR DESCRIPTION
## Summary
- Embed package version (`__version__`) in all injection block opening comments: `<!-- ltk:boot task_id=X version=0.1.0 -->`
- Updated regex patterns match blocks with or without `version=` for backward compatibility
- Heartbeat meta tag: `<!-- ltk:meta task_id=X status=Y version=0.1.0 -->`
- Boot/Agents tags: `<!-- ltk:boot task_id=X version=0.1.0 -->`

## Test plan
- [x] 6 new tests: version presence in heartbeat/boot/agents + backward compat (old blocks replaced)
- [x] Full suite (273 tests) passes
- [x] ruff check + format clean
- [x] mypy strict clean (pre-existing lock.py issue only)

Closes #27